### PR TITLE
[FEAT] coalition 추가 (#2)

### DIFF
--- a/routes/users.js
+++ b/routes/users.js
@@ -6,6 +6,26 @@ const dayjs = require('dayjs');
 const User = require('../stores/User');
 const ObjectUtils = require('../common/ObjectUtils');
 
+const END_POINT_42_API = "https://api.intra.42.fr";
+
+const get42UserCoalition = async (username, headers) => {
+  const coalitionUri = `${END_POINT_42_API}/v2/users/${username}/coalitions`;
+
+  const { data } = await axios.get(coalitionUri, headers)
+    .catch(e => {
+      const error = new Error(e.message);
+      console.log(e.message);
+      error.status = e.response.status;
+      if (error.status === 401) {
+        res.redirect('/login/42');
+        return;
+      }
+      next(error);
+    })
+    .finally(() => { });
+  return (data[0]);
+};
+
 /* GET users listing. */
 router.get('/', ensureLoggedIn('/login/42'), async function (req, res, next) {
   const username = req.query.u;
@@ -18,13 +38,17 @@ router.get('/', ensureLoggedIn('/login/42'), async function (req, res, next) {
       'headers':
         { 'Authorization': 'Bearer ' + accessToken }
     }
-    const uri = 'https://api.intra.42.fr/v2/users/' + username;
+    const uri = `${END_POINT_42_API}/v2/users/${username}`;
     axios.get(uri, headers)
       .then(async response => {
-        const one = response.data;
+        const one = {...response.data, 'coalition': await get42UserCoalition(username, headers)};
         ObjectUtils.calcDiff(one.projects_users, 'marked_at');
         await User.save(one);
-        res.render('user', { user: one, updatedAt: dayjs().format('YYYY/MM/DD HH:mm:ss'), dayjs });
+        res.render('user', { 
+          user: one, 
+          updatedAt: dayjs().format('YYYY/MM/DD HH:mm:ss'), 
+          dayjs 
+        });
       })
       .catch(e => {
         const error = new Error(e.message);
@@ -40,9 +64,12 @@ router.get('/', ensureLoggedIn('/login/42'), async function (req, res, next) {
   } else {
     const one = (typeof user.data === 'string') ? JSON.parse(user.data) : user.data;
     ObjectUtils.calcDiff(one.projects_users, 'marked_at');
-    res.render('user', { user: one, updatedAt: dayjs(user.updatedAt).format('YYYY/MM/DD HH:mm:ss'), dayjs })
+    res.render('user', { 
+      user: one, 
+      updatedAt: dayjs(user.updatedAt).format('YYYY/MM/DD HH:mm:ss'), 
+      dayjs, 
+    })
   }
-
 });
 
 module.exports = router;

--- a/views/user.ejs
+++ b/views/user.ejs
@@ -8,6 +8,10 @@
     info at: <%= updatedAt %>
     <button id="update">update</button>
   </p>
+  <p>
+    <%= user.coalition.name %>
+  </p>
+  <img id="coalition" src="<%= user.coalition.cover_url %>"/>
   <h3>Profile</h3>
   <div><img src="<%= user.image_url %>" alt="<%= user.login %> image" id="profile-image"></div>
   <dl>
@@ -94,5 +98,6 @@
     var diff = Number(item.innerText) / 8;
     item.style = 'font-size: x-small; background-color: #00babc; height: 10px; width: ' + diff + 'px;';
   });
-
+  const coalition = document.getElementById('coalition');
+  coalition.style = 'height: 300px; width: 600px;';
 </script>

--- a/views/user.ejs
+++ b/views/user.ejs
@@ -79,7 +79,7 @@
   <%= JSON.stringify(user, null, 2) %>
 </pre>
 <script>
-  var updBtn = document.getElementById('update');
+  const updBtn = document.getElementById('update');
   updBtn.addEventListener('click', function(e){
     var qs = location.search;
     var url = location.pathname;
@@ -89,7 +89,7 @@
       location.href = url;
     }
   });
-  var list = document.querySelectorAll('.diff');
+  const list = document.querySelectorAll('.diff');
   list.forEach(item => {
     var diff = Number(item.innerText) / 8;
     item.style = 'font-size: x-small; background-color: #00babc; height: 10px; width: ' + diff + 'px;';


### PR DESCRIPTION
#### 변경사항
- coalition을 추가했습니다.
  - 길드 정보의 경우 기존 api에는 길드 가입 유무의 정보만 있어서 get42UserCoalition() 함수로 따로 coalitions 정보를 얻어왔습니다.

#### 버그
- `user.ejs`에서 `<%= user.coalition.name %>`로 불러오는데 기존 sqlite에 저장된 user들은 coalition 정보가 없어서 err가 발생합니다.
  - 해결 방안: sqlite 초기화 

#### coalition의 data 구조
```js
data: [
    {
      id: 87,
      name: 'Gam',
      slug: 'gam',
      image_url: 'https://cdn.intra.42.fr/coalition/image/87/gam-svg-svg__3_.svg',
      cover_url: 'https://cdn.intra.42.fr/coalition/cover/87/gam_cover.jpg',
      color: '#4c83a4',
      score: 21645,
      user_id: 82562
    }
  ]
```

#### PR 적용된 페이지 화면
<img src="https://user-images.githubusercontent.com/22424891/114921215-44515b00-9e65-11eb-8362-6a98aff14a19.png" height="300px" />