### PR TITLE
[FIX] consider user === null

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ package-lock.json
 .vscode
 .env
 *.log
+
+# sonarqube
+.scannerwork

--- a/batch/sync.js
+++ b/batch/sync.js
@@ -39,7 +39,7 @@ async function updateList(list, accessToken) {
     var user = list[idx];
     console.log(idx, user.id, user.username);
     try {
-      userService.updateBatch(user, accessToken);
+      userService.updateBatch(user.username, accessToken, user.coalition);
     } catch (e) {
       console.log(`err: ${user.username}, e.message`);
     }

--- a/batch/sync.js
+++ b/batch/sync.js
@@ -39,7 +39,7 @@ async function updateList(list, accessToken) {
     var user = list[idx];
     console.log(idx, user.id, user.username);
     try {
-      userService.updateBatch(user.username, accessToken, user.coalition);
+      await userService.updateBatch(user.username, accessToken, user.coalition);
     } catch (e) {
       console.log(`err: ${user.username}, e.message`);
     }

--- a/routes/users.js
+++ b/routes/users.js
@@ -10,15 +10,23 @@ const userService = require('../services/userService');
 router.get('/', ensureLoggedIn('/login/42'), async function (req, res, next) {
   const username = req.query.u;
   const refresh = req.query.r;
-  const user = await userService.findOne(username);
-  let coalition = (user && typeof user.coalition === 'string') ? JSON.parse(user.coalition) : user.coalition;
+  let coalition;
+  let user;
+
+  try {
+    user = await userService.findOne(username);
+    if (user !== null)
+      coalition = (user && typeof user.coalition === 'string') ? JSON.parse(user.coalition) : user.coalition;
+  } catch (err) {
+    console.log("[user.js] findOne: ", err);
+  }
   let one;
   if (!user || refresh) {
     try {
       one = await userService.updateOne(username, req.session.accessToken);
       coalition = one.coalition;
     } catch (err) {
-      const error = new Error("[User.js] getUri, getCoalition: " + err.message);
+      const error = new Error("[user.js] getUri, getCoalition: " + err.message);
       error.status = (err.response) ? err.response.status : 500;
       if (error.status === 401) {
         res.redirect('/login/42');

--- a/routes/users.js
+++ b/routes/users.js
@@ -56,7 +56,7 @@ router.get('/', ensureLoggedIn('/login/42'), async function (req, res, next) {
   }
   res.render('user', { 
     user: one, 
-    updatedAt: dayjs(!user || refresh ?undefined:user.updatedAt).format('YYYY/MM/DD HH:mm:ss'),
+    updatedAt: dayjs(!user || refresh ? undefined : user.updatedAt).format('YYYY/MM/DD HH:mm:ss'),
     dayjs, 
   })
 });

--- a/routes/users.js
+++ b/routes/users.js
@@ -15,9 +15,10 @@ router.get('/', ensureLoggedIn('/login/42'), async function (req, res, next) {
 
   try {
     user = await userService.findOne(username);
-    if (user !== null)
-      coalition = (user && typeof user.coalition === 'string') ? JSON.parse(user.coalition) : user.coalition;
-  } catch (err) {
+    if (user !== null) {
+        coalition = (user && typeof user.coalition === 'string') ? JSON.parse(user.coalition) : user.coalition;
+      }
+    } catch (err) {
     console.log("[user.js] findOne: ", err);
   }
   let one;

--- a/routes/users.js
+++ b/routes/users.js
@@ -9,8 +9,9 @@ const ObjectUtils = require('../common/ObjectUtils');
 const END_POINT_42_API = "https://api.intra.42.fr";
 
 const coalitionErrHandling = (coalition) =>{
-  if (coalition)
+  if (coalition) {
     return (coalition);
+  }
   return ({
     name: '',
     cover_url: ''
@@ -55,9 +56,7 @@ router.get('/', ensureLoggedIn('/login/42'), async function (req, res, next) {
   }
   res.render('user', { 
     user: one, 
-    updatedAt: !user || refresh ?
-      dayjs().format('YYYY/MM/DD HH:mm:ss') :
-      dayjs(user.updatedAt).format('YYYY/MM/DD HH:mm:ss'),
+    updatedAt: dayjs(!user || refresh ?undefined:user.updatedAt).format('YYYY/MM/DD HH:mm:ss'),
     dayjs, 
   })
 });

--- a/routes/users.js
+++ b/routes/users.js
@@ -24,8 +24,12 @@ router.get('/', ensureLoggedIn('/login/42'), async function (req, res, next) {
   let one;
   if (!user || refresh) {
     try {
-      one = await userService.updateOne(username, req.session.accessToken);
-      coalition = one.coalition;
+      if (!coalition) {
+        one = await userService.updateOne(username, req.session.accessToken);
+        coalition = one.coalition;
+      } else {
+        one = await userService.updateBatch(username, req.session.accessToken, coalition);
+      }
     } catch (err) {
       const error = new Error("[user.js] getUri, getCoalition: " + err.message);
       error.status = (err.response) ? err.response.status : 500;

--- a/services/userService.js
+++ b/services/userService.js
@@ -38,12 +38,12 @@ const userService = {
     await userService.save(one, checkIfCoalition(one.coalition));
     return one;
   },
-  updateBatch: async function (user, accessToken) {
-    const userUri = `${END_POINT_42_API}/v2/users/${user.username}`;
+  updateBatch: async function (username, accessToken, coalition) {
+    const userUri = `${END_POINT_42_API}/v2/users/${username}`;
     const response = await axios.all([axios42(accessToken).get(userUri)]);
     one = { ...response[0].data };
     ObjectUtils.calcDiff(one.projects_users, 'marked_at');
-    await userService.save(one, checkIfCoalition(user.coalition));
+    await userService.save(one, checkIfCoalition(coalition));
     return one;
   }
 };

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,14 @@
+# must be unique in a given SonarQube instance
+sonar.projectKey=42seoul-info:site
+
+# --- optional properties ---
+
+sonar.projectName=42SeoulInfo
+sonar.projectVersion=1.0
+ 
+# Path is relative to the sonar-project.properties file. Defaults to .
+sonar.sources=.
+sonar.exclusions=test/**, node_modules/**, public/**
+ 
+# Encoding of the source code. Default is default system encoding
+sonar.sourceEncoding=UTF-8

--- a/stores/User.js
+++ b/stores/User.js
@@ -26,7 +26,7 @@ async function save(user, coalition) {
   });
   const id = (result[0]) ? result[0].dataValues.id : null;
   const result2 = await User.upsert({ id: id, username: user.login, data: user, coalition });
-  console.log(result2);
+  console.log("[User.js] save: ", result2);
   return result2;
 }
 


### PR DESCRIPTION
#### 추가 사항
- 아래 사항들을 구현하기 위해 updateBatch 함수를 Refactoring 했습니다. #10
  - [x] Refresh의 경우 coalition 변경이 빈번하지 않다면 배치에서는 호출 제외
  - [x] Refresh의 경우 coalition 이전 값을 승계. 또는 coalition 개별 업데이트
- sonarqube config #4 
길드는 지금까지 4시즌이 있었지만 한번 지정되면 변경이 되지않아서 제외시키는 방향으로 코드를 짰습니다. 나중에 길드가 변경이 된다면 일괄적으로 바꿔주면 좋을것같다고 생각합니다. 이 부분에 대해서는 어떻게 생각하시나요? 

#### 수정 사항
  - sqlite findOne() 값을 찾지 못했을때 null이 반환되어 user에 null이 할당됩니다.
  - 이때, 이전 코드는 user.coalition에 접근을 해서 오류가 나서 수정했습니다.
  - 추가적으로 이 오류가 console에 나타나지 않아서 try catch를 추가했습니다.
---
#### 갑자스런 42api 구조 변경..? (4월 23일 13시)
- api에서 받아오는 데이터 값의 구조가 많이 변했습니다... 이에따라 전체 로직을 수정해야할것같습니다. 많이 당황스럽습니다..#12
- 새로 바뀐 구조에서는 프로젝트별 기간이 존재하지 않습니다...ㅠ 어떻게하면 좋을까요..ㅠ
- 현재 PR은 42API 바뀌기전을 기준으로 작성된 코드입니다.
- Before
```js
{
  "id": 69063,
  "email": "holee@student.42seoul.kr",
  "login": "holee",
  "first_name": "Hochan",
  "last_name": "Lee",
  "usual_first_name": null,
  "url": "https://api.intra.42.fr/v2/users/holee",
  "phone": "hidden",
  "displayname": "Hochan Lee",
  "usual_full_name": "Hochan Lee",
  "image_url": "https://cdn.intra.42.fr/users/holee.jpg",
  "staff?": false,
  "correction_point": 22,
  "pool_month": "february",
  "pool_year": "2020",
  "location": null,
  "wallet": 66,
  "anonymize_date": "2022-04-22T00:00:00.000+09:00",
  "groups": [],
  "cursus_users": [
    {
      "grade": null,
      "level": 9.18,
      "skills": [
        {
          "id": 4,
          "name": "Unix",
          "level": 10.95
        },
        {
          "id": 1,
          "name": "Algorithms & AI",
          "level": 8.44
        },
        {
          "id": 3,
          "name": "Rigor",
          "level": 6.35
        },
        {
          "id": 14,
          "name": "Adaptation & creativity",
          "level": 2.9
        }
      ],
      "blackholed_at": null,
      "id": 85197,
      "begin_at": "2020-01-20T00:00:00.000Z",
      "end_at": "2020-02-14T14:00:00.000Z",
      "cursus_id": 9,
      "has_coalition": true,
      "user": {
        "id": 69063,
        "login": "holee",
        "url": "https://api.intra.42.fr/v2/users/holee"
      },
      "cursus": {
        "id": 9,
        "created_at": "2015-11-04T10:58:13.979Z",
        "name": "C Piscine",
        "slug": "c-piscine"
      }
    },
    {
      "grade": "Learner",
      "level": 5.07,
      "skills": [
        {
          "id": 3,
          "name": "Rigor",
          "level": 4.92
        },
        {
          "id": 2,
          "name": "Imperative programming",
          "level": 4.53
        },
        {
          "id": 17,
          "name": "Object-oriented programming",
          "level": 4.05
        },
        {
          "id": 10,
          "name": "Network & system administration",
          "level": 3.06
        },
        {
          "id": 1,
          "name": "Algorithms & AI",
          "level": 2.62
        },
        {
          "id": 4,
          "name": "Unix",
          "level": 2.2800000000000002
        },
        {
          "id": 5,
          "name": "Graphics",
          "level": 2.25
        }
      ],
      "blackholed_at": "2021-06-18T04:42:00.000Z",
      "id": 90261,
      "begin_at": "2020-02-24T04:42:00.000Z",
      "end_at": null,
      "cursus_id": 21,
      "has_coalition": true,
      "user": {
        "id": 69063,
        "login": "holee",
        "url": "https://api.intra.42.fr/v2/users/holee"
      },
      "cursus": {
        "id": 21,
        "created_at": "2019-07-29T08:45:17.896Z",
        "name": "42cursus",
        "slug": "42cursus"
      }
    }
  ],
  "projects_users": [
    {
      "id": 2082176,
      "occurrence": 0,
      "final_mark": null,
      "status": "in_progress",
      "validated?": null,
      "current_team_id": 3539809,
      "project": {
        "id": 1332,
        "name": "webserv",
        "slug": "webse
...
```
- After
```js
{
  data: {
    id: '69063',
    type: 'users',
    attributes: {
      email: 'holee@student.42seoul.kr',
      login: 'holee',
      'first-name': 'Hochan',
      'last-name': 'Lee',
      'usual-first-name': null,
      url: 'https://api.intra.42.fr/v2/users/holee',
      phone: 'hidden',
      displayname: 'Hochan Lee',
      'usual-full-name': 'Hochan Lee',
      'image-url': 'https://cdn.intra.42.fr/users/holee.jpg',
      'staff?': false,
      'correction-point': 22,
      'pool-month': 'february',
      'pool-year': '2020',
      location: null,
      wallet: 66,
      'anonymize-date': '2022-04-22T00:00:00.000+09:00'
    },
    relationships: {
      groups: [Object],
      'cursus-users': [Object],
      'projects-users': [Object],
      'languages-users': [Object],
      achievements: [Object],
      titles: [Object],
      'titles-users': [Object],
      partnerships: [Object],
      patroned: [Object],
      patroning: [Object],
      'expertises-users': [Object],
      roles: [Object],
      campus: [Object],
      'campus-users': [Object]
    }
  }
}
```